### PR TITLE
build:prod cross platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ All available flags:
 |  `postcssScssVersion`   | The postcss-scss version to be installed.                  | `string`         | `^3.0.4`                  |
 |  `skipTailwindInit`     | Skip initializing Tailwind.                                | `boolean`        | `false`                   |
 |  `tailwindVersion`      | The Tailwind version to be installed.                      | `string`         | `^2.0.1`                  |
-|  `installCrossPlatform` | Set the build:prod script to be cross-platform.            | `boolean`        | `true`                    |
+|  `disableCrossPlatform` | Set the build:prod script to be only UNIX compatible.      | `boolean`        | `false`                   |
 |  `crossEnvVersion`      | The cross-env version to be installed.                     | `string`         | `^7.0.3`                  |
 
 Advanced usage
@@ -83,10 +83,10 @@ ng add ngx-tailwind --tailwindVersion 1.9.6 --ngxBuildPlusVersion 10.1.1 --postc
 ```
 
 By default, `cross-env` is added to the `build:prod` script to be able to set `NODE_ENV=prod` cross-platform.
-If you want to override the default behavior, you can set the flag `--installCrossPlatform` to `false`:
+If you want to override the default behavior, you can set the flag `--disableCrossPlatform`:
 
 ```bash
-ng add ngx-tailwind --installCrossPlatform false
+ng add ngx-tailwind --disableCrossPlatform
 ```
 
 ## Developing

--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ All available flags:
 |  `postcssScssVersion`   | The postcss-scss version to be installed.                  | `string`         | `^3.0.4`                  |
 |  `skipTailwindInit`     | Skip initializing Tailwind.                                | `boolean`        | `false`                   |
 |  `tailwindVersion`      | The Tailwind version to be installed.                      | `string`         | `^2.0.1`                  |
+|  `installCrossPlatform` | Set the build:prod script to be cross-platform.            | `boolean`        | `true`                    |
+|  `crossEnvVersion`      | The cross-env version to be installed.                     | `string`         | `^7.0.3`                  |
 
 Advanced usage
 
@@ -78,6 +80,13 @@ Want to integrate Tailwind CSS in version 1.x.x? No problem:
 
 ```bash
 ng add ngx-tailwind --tailwindVersion 1.9.6 --ngxBuildPlusVersion 10.1.1 --postcssVersion 7.0.35 --postcssImportVersion 12.0.1 --postcssLoaderVersion 4.0.4 --postcssScssVersion 3.0.4
+```
+
+By default, `cross-env` is added to the `build:prod` script to be able to set `NODE_ENV=prod` cross-platform.
+If you want to override the default behavior, you can set the flag `--installCrossPlatform` to `false`:
+
+```bash
+ng add ngx-tailwind --installCrossPlatform false
 ```
 
 ## Developing

--- a/src/ng-add/index.ts
+++ b/src/ng-add/index.ts
@@ -108,7 +108,7 @@ function addDependencies(_options: Schema): Rule {
       version: _options.ngxBuildPlusVersion,
     });
 
-    if (_options.installCrossPlatform) {
+    if (!_options.disableCrossPlatform) {
       addPackageJsonDependency(host, {
         type: NodeDependencyType.Dev,
         name: 'cross-env',
@@ -211,10 +211,10 @@ function addNpmScripts(_options: Schema): Rule {
 
     const pkg = JSON.parse(buffer.toString());
 
-    if (_options.installCrossPlatform) {
-      pkg.scripts['build:prod'] = 'cross-env NODE_ENV=production ng build --prod';
-    } else {
+    if (_options.disableCrossPlatform) {
       pkg.scripts['build:prod'] = 'NODE_ENV=production ng build --prod';
+    } else {
+      pkg.scripts['build:prod'] = 'cross-env NODE_ENV=production ng build --prod';
     }
 
     tree.overwrite(pkgPath, JSON.stringify(pkg, null, 2));

--- a/src/ng-add/index.ts
+++ b/src/ng-add/index.ts
@@ -107,6 +107,14 @@ function addDependencies(_options: Schema): Rule {
       name: 'ngx-build-plus',
       version: _options.ngxBuildPlusVersion,
     });
+
+    if (_options.installCrossPlatform) {
+      addPackageJsonDependency(host, {
+        type: NodeDependencyType.Dev,
+        name: 'cross-env',
+        version: _options.crossEnvVersion,
+      });
+    }
   };
 }
 
@@ -203,7 +211,11 @@ function addNpmScripts(_options: Schema): Rule {
 
     const pkg = JSON.parse(buffer.toString());
 
-    pkg.scripts['build:prod'] = 'NODE_ENV=production ng build --prod';
+    if (_options.installCrossPlatform) {
+      pkg.scripts['build:prod'] = 'cross-env NODE_ENV=production ng build --prod';
+    } else {
+      pkg.scripts['build:prod'] = 'NODE_ENV=production ng build --prod';
+    }
 
     tree.overwrite(pkgPath, JSON.stringify(pkg, null, 2));
     return tree;

--- a/src/ng-add/schema.json
+++ b/src/ng-add/schema.json
@@ -71,6 +71,16 @@
       "type": "string",
       "description": "The Tailwind version to be installed.",
       "default": "^2.0.1"
+    },
+    "crossEnvVersion": {
+      "type": "string",
+      "description": "The cross-env version to be installed.",
+      "default": "^7.0.3"
+    },
+    "installCrossPlatform": {
+      "type": "boolean",
+      "description": "Set the build:prod script to be cross-platform.",
+      "default": true
     }
   }
 }

--- a/src/ng-add/schema.json
+++ b/src/ng-add/schema.json
@@ -77,10 +77,10 @@
       "description": "The cross-env version to be installed.",
       "default": "^7.0.3"
     },
-    "installCrossPlatform": {
+    "disableCrossPlatform": {
       "type": "boolean",
-      "description": "Set the build:prod script to be cross-platform.",
-      "default": true
+      "description": "Set the build:prod script to be only UNIX compatible.",
+      "default": false
     }
   }
 }

--- a/src/ng-add/schema.ts
+++ b/src/ng-add/schema.ts
@@ -50,9 +50,9 @@ export interface Schema {
   tailwindVersion: string;
 
   /**
-   * Set the build:prod script to be cross-platform.
+   * Set the build:prod script to be only UNIX compatible.
    */
-  installCrossPlatform: boolean;
+  disableCrossPlatform?: boolean;
 
   /**
    * cross-env version.

--- a/src/ng-add/schema.ts
+++ b/src/ng-add/schema.ts
@@ -48,6 +48,16 @@ export interface Schema {
    * Tailwind CSS version.
    */
   tailwindVersion: string;
+
+  /**
+   * Set the build:prod script to be cross-platform.
+   */
+  installCrossPlatform: boolean;
+
+  /**
+   * cross-env version.
+   */
+  crossEnvVersion: string;
 }
 
 export type CssFormat = 'css' | 'scss';


### PR DESCRIPTION
Uses `cross-env` in the build:prod script unless a flag `--disableCrossPlatform` is passed. There's also a new argument to set the version of `cross-env` called `crossEnvVersion`, the default being `^7.0.3`.

I could not test the modifications on a real Angular project (files, for some reason, weren't being created nor modified by the schematic).

Refs: #12